### PR TITLE
Fix changelog txml to groovy string escaping

### DIFF
--- a/src/groovy/grails/plugin/databasemigration/ChangelogXml2Groovy.groovy
+++ b/src/groovy/grails/plugin/databasemigration/ChangelogXml2Groovy.groovy
@@ -76,16 +76,16 @@ class ChangelogXml2Groovy {
 		String delimiter = ''
 
 		if (text) {
-			local.append '"'
-			local.append text.replaceAll('\n', '\\\\n')
-			local.append '"'
+			local.append '"""'
+			local.append text.replaceAll(/(\$|\\)/, /\\$1/)
+			local.append '"""'
 			delimiter = ', '
 		}
 
 		node.attributes().each { name, value ->
 			local.append delimiter
 			local.append name
-			local.append(': "').append(value).append('"')
+			local.append(': "').append(value.replaceAll(/(\$|\\|\\n)/, /\\$1/)).append('"')
 			delimiter = ', '
 		}
 


### PR DESCRIPTION
Fix  changelog XML to Groovy string escaping. use multiline delimiting for text and use regex replace for $ \ and \n where needed.

doing the initial changelog for an Oracle DB caused invalid groovy code to be generated because $ \ were in the text e.g. column(name: "SYS_NC00008$") and views contain a lot of SQL including " so for text nodes I replaced the gstring " with a multiline """ and just replaced $ and \ with a single regex.
