### PR TITLE
Contexts support in migration runner

### DIFF
--- a/src/docs/guide/3 Configuration.gdoc
+++ b/src/docs/guide/3 Configuration.gdoc
@@ -5,6 +5,7 @@ There are a few configuration options for the plugin:
 grails.plugin.databasemigration.changelogLocation | @grails-app/migrations@ | the folder containing the main changelog file (which can include one or more other files)
 grails.plugin.databasemigration.changelogFileName | @changelog.groovy@ | the name of the main changelog file
 grails.plugin.databasemigration.changelogProperties | none | a map of properties to use for property substitution in Groovy DSL changelogs
+grails.plugin.databasemigration.contexts | none | A comma-delimited list of [context|http://www.liquibase.org/manual/contexts] names. If specified, only changesets tagged with one of the context names will be run
 grails.plugin.databasemigration.dbDocLocation | @target/dbdoc@ | the directory where the output from the [dbm-db-doc|Documentation Scripts] script is written
 grails.plugin.databasemigration.updateOnStart | @false@ | if @true@ then changesets from the specified list of names will be run at startup
 grails.plugin.databasemigration.updateOnStartFileNames | none | one or more file names (relative to @changelogLocation@) to run at startup if @updateOnStart@ is @true@

--- a/src/groovy/grails/plugin/databasemigration/MigrationRunner.groovy
+++ b/src/groovy/grails/plugin/databasemigration/MigrationRunner.groovy
@@ -47,7 +47,7 @@ class MigrationRunner {
 				database = MigrationUtils.getDatabase(config.updateOnStartDefaultSchema ?: null)
 				for (name in config.updateOnStartFileNames) {
 					LOG.info "Running script '$name'"
-					MigrationUtils.getLiquibase(database, name).update null
+					MigrationUtils.getLiquibase(database, name).update config.contexts
 				}
 			}
 		}


### PR DESCRIPTION
Hi Burt

I had need for use of contexts during application start. I created one changeset that loads test data to application, and I didn't want to execute this changeset on production version, so this change solved my problem. If you are interested please pull the changes.

Best regards
Radosław Zubek
