### PR TITLE
GPDATABASEMIGRATION-43

### DIFF
--- a/src/groovy/grails/plugin/databasemigration/MigrationRunner.groovy
+++ b/src/groovy/grails/plugin/databasemigration/MigrationRunner.groovy
@@ -45,6 +45,10 @@ class MigrationRunner {
 		try {
 			MigrationUtils.executeInSession {
 				database = MigrationUtils.getDatabase(config.updateOnStartDefaultSchema ?: null)
+                if (config.dropOnStart) {
+                    LOG.warn "Dropping tables..."
+                    MigrationUtils.getLiquibase(database).dropAll()
+                }
 				for (name in config.updateOnStartFileNames) {
 					LOG.info "Running script '$name'"
 					MigrationUtils.getLiquibase(database, name).update null


### PR DESCRIPTION
allow updateOnStart to optionally drop all tables before running migrations scripts
