### PR TITLE
upgraded to liquibase 2.0.2 that escapes field names properly under Oracle 

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -19,7 +19,7 @@ grails.project.dependency.resolution = {
 
 	dependencies {
 
-		compile('org.liquibase:liquibase-core:2.0.1') {
+		compile('org.liquibase:liquibase-core:2.0.2') {
 			transitive = false
 		}
 


### PR DESCRIPTION
for example - I have in a class field entitled number, and number is reserved word in Oracle. Liquibase 2.0.1 did not escape NUMBER by create table statements.
