### PR TITLE
added grails.plugin.databasemigration.forceAutoMigrate param 

### DIFF
--- a/src/groovy/grails/plugin/databasemigration/MigrationUtils.groovy
+++ b/src/groovy/grails/plugin/databasemigration/MigrationUtils.groovy
@@ -141,7 +141,7 @@ class MigrationUtils {
 	static boolean canAutoMigrate() {
 
 		// in a war
-		if (application.warDeployed) {
+		if (application.warDeployed || getConfig()?.forceAutoMigrate) {
 			return true
 		}
 


### PR DESCRIPTION
It can be used for forcing auto migrate, no matter how the application is started. I find it useful if you want to check if migration is performed well (through some functional tests for example). At the moment, auto migration can be performed if the application is deployed from war file or started using run-app target.
