### PR TITLE
Do not create grails-app/migrations when changelogLocation is defined

### DIFF
--- a/scripts/_Install.groovy
+++ b/scripts/_Install.groovy
@@ -1,1 +1,4 @@
-ant.mkdir dir: "$basedir/grails-app/migrations"
+createConfig()
+def conf = config.grails.plugin.databasemigration
+String changelogLocation = conf.changelogLocation ?: 'grails-app/migrations'
+ant.mkdir dir: "$basedir/$changelogLocation"


### PR DESCRIPTION
This bug happens when plugins are installed for a existing project
