### PR TITLE
Better logging of exceptions from Liquibase validation

### DIFF
--- a/scripts/_DatabaseMigrationCommon.groovy
+++ b/scripts/_DatabaseMigrationCommon.groovy
@@ -59,6 +59,7 @@ doAndClose = { Closure c ->
 		}
 	}
 	catch (e) {
+                printMessage "Caught exception: $e"
 		ScriptUtils.printStackTrace e
 		exit 1
 	}


### PR DESCRIPTION
When Liquibase validation fails the thrown exception is not being logged by ScriptUtils.printStackTrace
