### PR TITLE
fixed reverse logic for length_types (not) having decimal digits

### DIFF
--- a/src/groovy/grails/plugin/databasemigration/GormColumn.groovy
+++ b/src/groovy/grails/plugin/databasemigration/GormColumn.groovy
@@ -42,7 +42,7 @@ class GormColumn extends Column {
 		if (!typeHasScaleAndPrecision(dataType)) {
 			decimalDigits = 0
 		}
-		if (!typeHasLength(dataType)) {
+		if (typeHasLength(dataType)) {
 			decimalDigits = 0
 		}
 


### PR DESCRIPTION
as i understand it, LENGTH_TYPES contains types that do have a length, e.g. VARCHAR(255), but _not_ a scale/precision.

so, if a typeHasLength it should have 0 decimalDigits.

this fixed false positives with dbm-gorm-diff for numeric types with scale for me (postgresql).
