### PR TITLE
GPDATABASEMIGRATION-124

### DIFF
--- a/src/groovy/grails/plugin/databasemigration/GormColumn.groovy
+++ b/src/groovy/grails/plugin/databasemigration/GormColumn.groovy
@@ -102,4 +102,16 @@ class GormColumn extends Column {
 
 		name.equalsIgnoreCase(column.name) && column.table == table && column.view == view
 	}
+	
+	// have to re-implement since base class does case-sensitive column-name comparison
+	@Override
+	public int compareTo(Column o) {
+		int d
+		if(table || o.table) {
+			d = table <=> o.table
+		} else {
+			d = view <=> o.view
+		}
+		d != 0 ? d : name.compareToIgnoreCase(o.name)
+	}
 }

--- a/test/cli/grails/plugin/databasemigration/DbmGormDiffTests.groovy
+++ b/test/cli/grails/plugin/databasemigration/DbmGormDiffTests.groovy
@@ -50,6 +50,9 @@ class DbmGormDiffTests extends AbstractScriptTests {
 
 		// no corresponding domain class
 		assertTrue diffOutput.contains('<dropTable tableName="PERSON"/>')
+		
+		assertFalse 'Must not drop columns in RDBMS which convert column names to upper-case', 
+			diffOutput.contains('<dropColumn columnName="NAME" tableName="THING"/>')
 	}
 
 	void testGormDiff_Groovy() {
@@ -84,6 +87,9 @@ class DbmGormDiffTests extends AbstractScriptTests {
 
 		// no corresponding domain class
 		assertTrue diffOutput.contains('dropTable(tableName: "PERSON")')
+		
+		assertFalse 'Must not drop columns in RDBMS which convert column names to upper-case', 
+			diffOutput.contains('dropColumn(columnName: "ID", tableName: "THING")')
 	}
 
 	void testGormDiff_STDOUT() {
@@ -109,6 +115,9 @@ class DbmGormDiffTests extends AbstractScriptTests {
 
 		// no corresponding domain class
 		assertTrue output.contains('<dropTable tableName="PERSON"/>')
+		
+		assertFalse 'Must not drop columns in RDBMS which convert column names to upper-case',
+			output.contains('<dropColumn columnName="NAME" tableName="THING"/>')
 	}
 
 	void testGormDiffForSecondaryDataSource_XML() {


### PR DESCRIPTION
This is a fix for GPDATABASEMIGRATION-124. 
With RDBMS that convert column names to upper case, like H2 does, `dbm-gorm-diff` is broken. It creates drop-column commands for all existing columns.

Background: GormColumn objects must be compared case-insensitive. GormColumn already implemented a case-insensitive `equals()` method, but Groovy's `==` Operator does not use `equals()` if the class implements the `Comparable` interface. Instead `compareTo()` is used. And since this method was not overridden in GormColumn, the case-_sensitive_ implementation of Liquibase's Column-class was used.

This fix consists of implementing `compareTo()` in a case-insensitive way in GormColumn. I also extended the relevant cli tests.
