### PR TITLE
Application context is not loaded correctly and broke all scripts that request a bean from the contest

### DIFF
--- a/scripts/_DatabaseMigrationCommon.groovy
+++ b/scripts/_DatabaseMigrationCommon.groovy
@@ -24,6 +24,8 @@ includeTargets << grailsScript('_GrailsBootstrap')
 target(dbmInit: 'General initialization, also creates a Liquibase instance') {
 	depends(classpath, checkVersion, configureProxy, enableExpandoMetaClass, bootstrap, loadApp)
 
+	configureApp()
+
 	try {
 		hyphenatedScriptName = GrailsNameUtils.getScriptName(scriptName)
 		MigrationUtils = classLoader.loadClass('grails.plugin.databasemigration.MigrationUtils')


### PR DESCRIPTION
Calling `configureApp` target from `bootstrap` script initialize application context with all defined bean. This solve all problems (undefined bean, npe) that I had using `database-migration` scripts with grails 2.3.0.GA.
