### PR TITLE
GPDATABASEMIGRATION-161: Plugins loaded twice fix

### DIFF
--- a/scripts/_DatabaseMigrationCommon.groovy
+++ b/scripts/_DatabaseMigrationCommon.groovy
@@ -22,9 +22,7 @@ import grails.util.GrailsNameUtils
 includeTargets << grailsScript('_GrailsBootstrap')
 
 target(dbmInit: 'General initialization, also creates a Liquibase instance') {
-	depends(classpath, checkVersion, configureProxy, enableExpandoMetaClass, compile, bootstrap, loadApp)
-
-	configureApp()
+    depends(classpath, checkVersion, configureProxy, enableExpandoMetaClass, compile, bootstrapOnce)
 
 	try {
 		hyphenatedScriptName = GrailsNameUtils.getScriptName(scriptName)


### PR DESCRIPTION
Used the GPDATABASEMIGRATION-161 reporters suggestion, it allowed me to run "dbm-generate-changelog changelog.groovy" where I had the same trouble as reporter otherwise.
