### PR TITLE
Adding an 'add migration' script to create a groovy migration file placeholder

### DIFF
--- a/scripts/DbmAddMigration.groovy
+++ b/scripts/DbmAddMigration.groovy
@@ -1,0 +1,49 @@
+/* Copyright 2010-2013 SpringSource.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author <a href='mailto:mgkimsal@gmail.com'>Michael Kimsal</a>
+ */
+
+includeTargets << new File("$databaseMigrationPluginDir/scripts/_DatabaseMigrationCommon.groovy")
+
+target(dbmAddMigration: 'Adds an empty migration file to the main changelog') {
+	depends dbmInit
+
+	String migrationName = argsList[0]
+	if (!migrationName) {
+		errorAndDie "The $hyphenatedScriptName script requires a migration name name argument"
+	}
+
+	String filename = MigrationUtils.getChangelogLocation(dsName) + '/' + migrationName+".groovy"
+	if (new File(filename).exists()) {
+		errorAndDie "File $filename already exists"
+	}
+
+	String user = (System.getProperty('user.name') ?: '').trim()
+	String author = user ? "$user (generated)" : 'example migration'
+
+	ant.copy(file: "$databaseMigrationPluginDir/src/resources/migration.template",
+					tofile: filename, verbose: true, overwrite: true) {
+		filterset {
+			filter token: 'author', value: author
+			filter token: 'id', value: migrationName
+		}
+	}
+
+	ScriptUtils.registerInclude filename, dsName
+}
+
+setDefaultTarget dbmAddMigration

--- a/src/resources/migration.template
+++ b/src/resources/migration.template
@@ -1,0 +1,17 @@
+// example migration file
+databaseChangeLog = {
+
+	changeSet(author: "@author@", id: "@id@") {
+// liquibase changes
+//		addNotNullConstraint(tableName: "tableName", columnName: "date_created")
+
+// grails changes
+		grailsChange {
+			change {
+//				sql.execute("")
+			}
+			rollback {
+			}
+		}
+	}
+}


### PR DESCRIPTION
...and automatically add it to the changelog file.

Have missed something like this for a while and thought I might as well try to get the ball rolling on adding something like this to the core plugin.  Groovy only right now - not sure how to make it XML as well.

Definitely open to learning how to do this a better way, but as I show Grails to more people, I realize manual migration creation is an extra step.  Having this be part of the core migrations would make it easier for people to get in to the migration habit.
