### PR TITLE
Adding reference doc for dbm-add-migration script

### DIFF
--- a/src/docs/ref/Maintenance Scripts/dbm-add-migration.gdoc
+++ b/src/docs/ref/Maintenance Scripts/dbm-add-migration.gdoc
@@ -1,0 +1,24 @@
+h1. dbm-add-migration
+
+h2. Purpose
+
+Adds a template migration file to your project and to the changelog file.
+
+h2. Description
+
+This script provides a template in which to place your migration behaviour code, whether
+grails code or raw SQL.
+
+Usage:
+{code:java}
+grails [environment] dbm-add-migration [migrationName]
+{code}
+
+Required arguments:
+
+* @migrationName@ - The name of the migration - will be used as a filename and the default migration id.
+
+
+{note}
+This script only supports .groovy-style migrations at the moment.
+{note}


### PR DESCRIPTION
Basic docs for dbm-add-migration

Didn't include anything in the main tutorial documentation - wasn't sure where to put it - but it's in the ref docs on the sidebar
