### PR TITLE
Fix MigrationUtils to use defaultSchema from Datasource.groovy

### DIFF
--- a/src/groovy/grails/plugin/databasemigration/MigrationUtils.groovy
+++ b/src/groovy/grails/plugin/databasemigration/MigrationUtils.groovy
@@ -105,6 +105,10 @@ class MigrationUtils {
 		def connection = findSessionFactory(dataSourceSuffix).currentSession.connection()
 
 		def dialect = application.config."$dsName".dialect
+		//append default schema if specified in DataSource.groovy hibernate closure
+		if(application.config.hibernate.default_schema) {
+		   defaultSchema = application.config.hibernate.default_schema
+		}
 		if (dialect) {
 			if (dialect instanceof Class) {
 				dialect = dialect.name


### PR DESCRIPTION
static Database getDatabase(String defaultSchema = null, String dsName = 'dataSource') {
		String dataSourceSuffix = extractSuffix(dsName)
		def connection = findSessionFactory(dataSourceSuffix).currentSession.connection()

		def dialect = application.config."$dsName".dialect
		if(application.config.hibernate.default_schema) {
		   defaultSchema = application.config.hibernate.default_schema
		}
		if (dialect) {
			if (dialect instanceof Class) {
				dialect = dialect.name
			}
		}
		else {
			dialect = application.mainContext.dialectDetector
		}

		getDatabase connection, defaultSchema, dialect.toString()
	}
