### PR TITLE
Fix ConcurrentModificationException when running dbm-gorm-diff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "com.jfrog.bintray" version "1.1"
 }
 
-version "2.0.0.RC1"
+version "2.0.0.RC2"
 group "org.grails.plugins"
 
 apply plugin: "spring-boot"
@@ -53,7 +53,8 @@ dependencyManagement {
 }
 
 dependencies {
-    compile 'org.liquibase:liquibase-core:3.3.2'
+    compile 'org.liquibase:liquibase-core:3.4.2'
+
     compile('org.liquibase.ext:liquibase-hibernate4:3.5') {
         exclude group: 'org.hibernate', module: 'hibernate-core'
         exclude group: 'org.hibernate.javax.persistence', module: 'hibernate-jpa-2.0-api'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-grailsVersion=3.0.1
+grailsVersion=3.0.11
 gradleWrapperVersion=2.3
 
 websiteUrl=http://grails-plugins.github.io/grails-database-migration

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 17 00:01:17 JST 2015
+#Wed Mar 09 10:35:09 GMT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "database-migration"

--- a/src/integration-test/groovy/org/grails/plugins/databasemigration/AutoRunWithSingleDataSourceSpec.groovy
+++ b/src/integration-test/groovy/org/grails/plugins/databasemigration/AutoRunWithSingleDataSourceSpec.groovy
@@ -18,6 +18,7 @@ package org.grails.plugins.databasemigration
 import grails.test.mixin.integration.Integration
 import groovy.sql.Sql
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Primary
 import org.springframework.test.context.ActiveProfiles
 import spock.lang.AutoCleanup
 import spock.lang.Specification

--- a/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
@@ -66,7 +66,7 @@ trait ApplicationContextDatabaseMigrationCommand implements DatabaseMigrationCom
     }
 
     @CompileDynamic
-    private Database createGormDatabase(ConfigurableApplicationContext applicationContext, String dataSource = null) {
+    private Database createGormDatabase(ConfigurableApplicationContext applicationContext, String dataSource) {
         String sessionFactoryName = dataSource ? '&sessionFactory_' + dataSource : '&sessionFactory'
 
         def sessionFactory = applicationContext.getBean(sessionFactoryName)

--- a/src/main/groovy/org/grails/plugins/databasemigration/command/DbmCreateChangelog.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/command/DbmCreateChangelog.groovy
@@ -16,6 +16,7 @@
 package org.grails.plugins.databasemigration.command
 
 import groovy.transform.CompileStatic
+import liquibase.serializer.ChangeLogSerializer
 import liquibase.serializer.ChangeLogSerializerFactory
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 
@@ -41,10 +42,10 @@ class DbmCreateChangelog implements ScriptDatabaseMigrationCommand {
             outputChangeLogFile.parentFile.mkdirs()
         }
 
-        def serializer = ChangeLogSerializerFactory.instance.getSerializer(filename)
+        ChangeLogSerializer serializer = ChangeLogSerializerFactory.instance.getSerializer(filename)
 
         outputChangeLogFile.withOutputStream { OutputStream out ->
-            serializer.write([], out)
+            serializer.write(new ArrayList(), out)
         }
 
         if (hasOption('add')) {

--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GrailsLiquibase.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GrailsLiquibase.groovy
@@ -23,6 +23,7 @@ import liquibase.exception.LiquibaseException
 import liquibase.integration.spring.SpringLiquibase
 import liquibase.resource.ClassLoaderResourceAccessor
 import liquibase.resource.CompositeResourceAccessor
+import liquibase.resource.ResourceAccessor
 import org.springframework.context.ApplicationContext
 
 import java.sql.Connection
@@ -42,7 +43,8 @@ class GrailsLiquibase extends SpringLiquibase {
 
     @Override
     protected Liquibase createLiquibase(Connection connection) throws LiquibaseException {
-        Liquibase liquibase = new Liquibase(getChangeLog(), new ClassLoaderResourceAccessor(), createDatabase(connection))
+        Liquibase liquibase = new Liquibase(getChangeLog(), new ClassLoaderResourceAccessor(), createDatabase
+                (connection, null))
         liquibase.setIgnoreClasspathPrefix(isIgnoreClasspathPrefix())
         if (parameters != null) {
             for (Map.Entry<String, String> entry : parameters.entrySet()) {
@@ -57,9 +59,10 @@ class GrailsLiquibase extends SpringLiquibase {
         return liquibase
     }
 
+
     @Override
-    protected Database createDatabase(Connection connection) throws DatabaseException {
-        Database database = super.createDatabase(connection)
+    protected Database createDatabase(Connection connection, ResourceAccessor accessor) throws DatabaseException {
+        Database database = super.createDatabase(connection, accessor)
 
         if (databaseChangeLogTableName) {
             database.databaseChangeLogTableName = databaseChangeLogTableName

--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogParser.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogParser.groovy
@@ -92,7 +92,7 @@ class GroovyChangeLogParser extends AbstractChangeLogParser {
                 databases = value.databases
                 value = value.value
             }
-            changeLogParameters.set(name as String, value as String, contexts as String, labels, databases)
+            changeLogParameters.set(name as String, value as String, contexts as String, labels, databases, true, null)
         }
     }
 }

--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSerializer.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSerializer.groovy
@@ -16,6 +16,7 @@
 package org.grails.plugins.databasemigration.liquibase
 
 import groovy.transform.CompileStatic
+import liquibase.changelog.ChangeLogChild
 import liquibase.changelog.ChangeSet
 import liquibase.serializer.ChangeLogSerializer
 import liquibase.serializer.LiquibaseSerializable
@@ -27,9 +28,9 @@ class GroovyChangeLogSerializer implements ChangeLogSerializer {
     private XMLChangeLogSerializer xmlChangeLogSerializer = new XMLChangeLogSerializer()
 
     @Override
-    void write(List<ChangeSet> changeSets, OutputStream out) throws IOException {
+    def <T extends ChangeLogChild> void write(List<T> changesets, OutputStream out) throws IOException {
         def xmlOutputStrem = new ByteArrayOutputStream()
-        xmlChangeLogSerializer.write(changeSets, xmlOutputStrem)
+        xmlChangeLogSerializer.write(changesets, xmlOutputStrem)
         out << ChangelogXml2Groovy.convert(xmlOutputStrem.toString())
     }
 
@@ -46,5 +47,10 @@ class GroovyChangeLogSerializer implements ChangeLogSerializer {
     @Override
     String serialize(LiquibaseSerializable object, boolean pretty) {
         throw new UnsupportedOperationException()
+    }
+
+    @Override
+    int getPriority() {
+        return 0
     }
 }


### PR DESCRIPTION
This fix upgrades liquibase-core to version 3.4.2, this has been identified as a
workaround solution to the concurrent modification exception being thrown by
gorm-diff, generate-changelog etc.

Some parts of the api in liquibase changed between 3.3 and 3.4, so while the
original error went away, bringing in 3.4.2 broken the dbmUpdate
functionality. This commit fixes this issue with also and no workarounds
should be needed.

This fixes #47 
