### PR TITLE
Fix multiple calls to grailsChange 'change' migration closure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
         exclude group: 'org.hibernate.javax.persistence', module: 'hibernate-jpa-2.0-api'
         exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
         exclude group: 'org.hibernate', module: 'hibernate-envers'
+        exclude group: 'org.liquibase', module: 'liquibase-core'
     }
     provided 'org.hibernate:hibernate-core:4.3.8.Final'
 

--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChange.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChange.groovy
@@ -78,6 +78,8 @@ class GroovyChange extends AbstractChange {
 
     boolean validateClosureCalled
 
+    boolean changeClosureCalled
+
     @Override
     void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         this.resourceAccessor = resourceAccessor
@@ -137,7 +139,13 @@ class GroovyChange extends AbstractChange {
 
         if (shouldRun() && changeClosure) {
             changeClosure.delegate = this
-            changeClosure()
+            try {
+                if(!changeClosureCalled) {
+                    changeClosure()
+                }
+            } finally {
+                changeClosureCalled = true
+            }
         }
 
         allStatements as SqlStatement[]

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommandSpec.groovy
@@ -93,6 +93,10 @@ abstract class ApplicationContextDatabaseMigrationCommandSpec extends DatabaseMi
             new CommandLineParser().parse(([commandClassName] + args.toList()) as String[])
         )
     }
+
+    void cleanup() {
+
+    }
 }
 
 @Entity

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommandSpec.groovy
@@ -50,4 +50,6 @@ abstract class DatabaseMigrationCommandSpec extends Specification {
 
         changeLogLocation = File.createTempDir()
     }
+
+
 }

--- a/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyPreconditionSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyPreconditionSpec.groovy
@@ -58,7 +58,7 @@ databaseChangeLog = {
             command.handle(getExecutionContext(DbmUpdateCommand))
 
         then:
-            executedChangeSets == ['1','1']
+            executedChangeSets == ['1']
     }
 
     def "changeSet precondition is not satisfied by using a simple assertion"() {
@@ -93,7 +93,7 @@ databaseChangeLog = {
             command.handle(getExecutionContext(DbmUpdateCommand))
 
         then:
-            executedChangeSets == ['2','2']
+            executedChangeSets == ['2']
     }
 
     def "changeSet precondition is not satisfied by using an assertion with a message"() {
@@ -128,7 +128,7 @@ databaseChangeLog = {
             command.handle(getExecutionContext(DbmUpdateCommand))
 
         then:
-            executedChangeSets == ['2','2']
+            executedChangeSets == ['2']
     }
 
     def "changeSet precondition is not satisfied by calling the fail method"() {
@@ -163,7 +163,7 @@ databaseChangeLog = {
             command.handle(getExecutionContext(DbmUpdateCommand))
 
         then:
-            executedChangeSets == ['2','2']
+            executedChangeSets == ['2']
     }
 
     def "changeSet precondition is not satisfied by throwing an exception"() {
@@ -198,7 +198,7 @@ databaseChangeLog = {
             command.handle(getExecutionContext(DbmUpdateCommand))
 
         then:
-            executedChangeSets == ['2','2']
+            executedChangeSets == ['2']
     }
 
     def "databaseChangeLog precondition is not satisfied"() {
@@ -278,6 +278,6 @@ databaseChangeLog = {
             command.handle(getExecutionContext(DbmUpdateCommand))
 
         then:
-            executedChangeSets == ['1', '1','2','2']
+            executedChangeSets == ['1','2']
     }
 }

--- a/src/test/resources/logback.groovy
+++ b/src/test/resources/logback.groovy
@@ -9,3 +9,10 @@ appender('STDOUT', ConsoleAppender) {
 }
 
 root(INFO, ['STDOUT'])
+
+logger("org.grails", DEBUG, ['STDOUT'], false)
+
+logger("liquibase", DEBUG, ['STDOUT'], false)
+
+
+


### PR DESCRIPTION
After upgrading to Liquibase 3.4.2 the grailsChange block in a changeset was executing the change closure at least twice on each execution. This was causing a number of tests to fail. This fix includes a guard which only allows the change closure to be executed once for a changeset. (Similar guards we're in place for the validate and init closures)

Fixes #47 