### PR TITLE
Put back default constructor to fix issue with migration on start :

### DIFF
--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GormDatabase.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GormDatabase.groovy
@@ -34,6 +34,9 @@ class GormDatabase extends HibernateDatabase {
     private Dialect dialect
     private Metadata metadata
 
+    GormDatabase() {
+    }
+
     GormDatabase(Dialect dialect, ServiceRegistry serviceRegistry) {
         this.dialect = dialect
         this.metadata = new MetadataSources(serviceRegistry).getMetadataBuilder().build();


### PR DESCRIPTION
liquibase: Can not use class org.grails.plugins.databasemigration.liquibase.GormDatabase as a Liquibase service because it does not have a no-argument constructor