### PR TITLE
fix for grails-plugins/grails-database-migration#157

### DIFF
--- a/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
@@ -82,7 +82,7 @@ trait ApplicationContextDatabaseMigrationCommand implements DatabaseMigrationCom
         String dataSourceName = getDataSourceName(dataSource)
         String sessionFactoryName = "sessionFactory"
         if (!isDefaultDataSource(dataSource)) {
-            sessionFactoryName = sessionFactoryName + '_' + dataSourceName
+            sessionFactoryName = sessionFactoryName + '_' + dataSource
         }
 
         def serviceRegistry = applicationContext.getBean(sessionFactoryName, SessionFactoryImplementor).serviceRegistry.parentServiceRegistry


### PR DESCRIPTION
when constructing the sessionFactory bean name for a secondary dataSource, just append the suffix, not the complete dataSource bean name (i.e. sessionFactory_another instead of sessionFactory_dataSource_another)