### PR TITLE
add config option for suppressFields

### DIFF
--- a/src/docs/asciidoc/configuration.adoc
+++ b/src/docs/asciidoc/configuration.adoc
@@ -23,6 +23,7 @@ There are a few configuration options for the plugin. All configurations are pre
 |autoMigrateScripts |['RunApp'] |the scripts when running auto-migrate. Useful to run auto-migrate during test phase with: ['RunApp', 'TestApp']
 |excludeObjects |none |A comma-delimited list of database object names to ignore while performing a dbm-gorm-diff or dbm-generate-gorm-changelog
 |includeObjects |none |A comma-delimited list of database object names to look for while performing a dbm-gorm-diff or dbm-generate-gorm-changelog
+|suppressFields |none |A comma-delimited list of database object fields to suppress when looking for differences while performing a dbm-gorm-diff or dbm-generate-gorm-changelog (in the format type:field)
 |databaseChangeLogTableName |'databasechangelog' |the Liquibase changelog record table name
 |databaseChangeLogLockTableName |'databasechangeloglock' |the Liquibase lock table name
 |==================================
@@ -49,4 +50,11 @@ The configuration for all data sources with same db schema would be:
 ----
 grails.plugin.databasemigration.updateAllOnStart = true
 grails.plugin.databasemigration.changelogFileName = changelog.groovy
+----
+
+*Suppress Fields:*
+
+When comparing different types of databases (such as Gorm to Oracle), liquibase can detect changes that aren't real.  For example, Oracle databases track if Foreign Keys are validatable, but that field causes a difference when compared to any other type of database.  To prevent these differences you can use the suppressFields config option:
+----
+grails.plugin.databasemigration.suppressFields = [ "ForeignKey:validate" ]
 ----

--- a/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
@@ -44,6 +44,7 @@ import liquibase.diff.output.StandardObjectChangeFilter
 import liquibase.exception.DatabaseException
 import liquibase.exception.LiquibaseException
 import liquibase.exception.LockException
+import liquibase.exception.UnexpectedLiquibaseException
 import liquibase.executor.Executor
 import liquibase.executor.ExecutorService
 import liquibase.executor.LoggingExecutor
@@ -55,9 +56,11 @@ import liquibase.resource.CompositeResourceAccessor
 import liquibase.resource.FileSystemResourceAccessor
 import liquibase.resource.ResourceAccessor
 import liquibase.statement.core.RawSqlStatement
+import liquibase.structure.DatabaseObject
 import liquibase.structure.core.Catalog
 import liquibase.util.LiquibaseUtil
 import liquibase.util.StreamUtil
+import liquibase.util.StringUtil
 import org.grails.build.parsing.CommandLine
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import org.grails.plugins.databasemigration.NoopVisitor
@@ -248,9 +251,36 @@ trait DatabaseMigrationCommand {
         commandScope.execute()
     }
 
+    void addSuppressedFields(CompareControl compareControl, String filter) {
+        filter = StringUtil.trimToNull(filter)
+        if (filter == null) {
+            return
+        }
+
+        for (String subfilter : filter.split("\\s*,\\s*")) {
+            String[] split = subfilter.split(":")
+            if (split.length != 2) {
+                throw new UnexpectedLiquibaseException("Unable to parse suppressed field: ${subfilter}")
+            } else {
+                String className = StringUtil.upperCaseFirst(split[0])
+                className = "liquibase.structure.core."+className
+                try {
+                    Class<DatabaseObject> clazz = (Class<DatabaseObject>) Class.forName(className)
+                    compareControl.addSuppressedField(clazz, split[1])
+                } catch (ClassNotFoundException e) {
+                    throw new UnexpectedLiquibaseException(e)
+                }
+            }
+        }
+    }
+
     void doDiffToChangeLog(File changeLogFile, Database referenceDatabase, Database targetDatabase) {
         def changeLogFilePath = changeLogFile?.path
         def compareControl = new CompareControl([] as CompareControl.SchemaComparison[], null as String)
+
+        String suppressFields = config.getProperty("${configPrefix}.suppressFields".toString(), String)
+        addSuppressedFields(compareControl, suppressFields)
+
         final CommandScope commandScope = new CommandScope("groovyDiffChangelog")
         commandScope.addArgumentValue(InternalDiffChangelogCommandStep.REFERENCE_DATABASE_ARG, referenceDatabase)
         commandScope.addArgumentValue(InternalDiffChangelogCommandStep.TARGET_DATABASE_ARG, targetDatabase)


### PR DESCRIPTION
Allows us to work around issues where liquibase detects a difference when comparing databases of different types by hooking into the supported liquibase CompareControl object to suppress fields.  Issues like #95 will be able to be fixed without having to wait for fixes to liquibase to be merged into the current release of the plugin.