### PR TITLE
Remove "dataSource_" from bean name as dataSourceName of GroovyChange when using additional dataSources

### DIFF
--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChange.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChange.groovy
@@ -92,6 +92,9 @@ class GroovyChange extends AbstractChange {
 
         ctx = parsedNode.getChildValue(null, 'applicationContext', ApplicationContext)
         dataSourceName = parsedNode.getChildValue(null, DATA_SOURCE_NAME_KEY, String)
+        if (dataSourceName.startsWith("dataSource_")) {
+            dataSourceName = dataSourceName.substring("dataSource_".length())
+        }
         initClosure = parsedNode.getChildValue(null, 'init', Closure)
         validateClosure = parsedNode.getChildValue(null, 'validate', Closure)
         changeClosure = parsedNode.getChildValue(null, 'change', Closure)


### PR DESCRIPTION
Fix for grails/gorm-hibernate5#965