### PR TITLE
Usea a bean reference for GrailsLiquibase to allow customisation by plugin users

### DIFF
--- a/src/main/groovy/org/grails/plugins/databasemigration/DatabaseMigrationGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/DatabaseMigrationGrailsPlugin.groovy
@@ -21,6 +21,7 @@ import liquibase.parser.ChangeLogParserFactory
 import liquibase.servicelocator.ServiceLocator
 import org.grails.plugins.databasemigration.liquibase.GormDatabase
 import org.grails.plugins.databasemigration.liquibase.GrailsLiquibase
+import org.grails.plugins.databasemigration.liquibase.GrailsLiquibaseFactory
 import org.grails.plugins.databasemigration.liquibase.GroovyChangeLogParser
 import org.springframework.context.ApplicationContext
 
@@ -47,7 +48,9 @@ class DatabaseMigrationGrailsPlugin extends Plugin {
     @Override
     Closure doWithSpring() {
         configureLiquibase()
-        return { -> }
+        return { ->
+            grailsLiquibaseFactory(GrailsLiquibaseFactory, applicationContext)
+        }
     }
 
     @Override
@@ -73,7 +76,7 @@ class DatabaseMigrationGrailsPlugin extends Plugin {
             }
 
             new DatabaseMigrationTransactionManager(applicationContext, dataSourceName).withTransaction {
-                GrailsLiquibase gl = new GrailsLiquibase(applicationContext)
+                GrailsLiquibase gl = applicationContext.getBean('grailsLiquibaseFactory', GrailsLiquibase)
                 gl.dataSource = getDataSourceBean(applicationContext, dataSourceName)
                 gl.dropFirst = config.getProperty("${configPrefix}.dropOnStart", Boolean, false)
                 gl.changeLog = config.getProperty("${configPrefix}.updateOnStartFileName", String, isDefaultDataSource(dataSourceName) ? 'changelog.groovy' : "changelog-${dataSourceName}.groovy")

--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GrailsLiquibaseFactory.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GrailsLiquibaseFactory.groovy
@@ -1,0 +1,24 @@
+package org.grails.plugins.databasemigration.liquibase
+
+import org.springframework.beans.factory.config.AbstractFactoryBean
+import org.springframework.context.ApplicationContext
+
+class GrailsLiquibaseFactory extends AbstractFactoryBean<GrailsLiquibase> {
+
+    private final ApplicationContext applicationContext
+
+    GrailsLiquibaseFactory(ApplicationContext applicationContext) {
+        setSingleton(false)
+        this.applicationContext = applicationContext
+    }
+
+    @Override
+    Class<?> getObjectType() {
+        return GrailsLiquibase
+    }
+
+    @Override
+    protected GrailsLiquibase createInstance() throws Exception {
+        return new GrailsLiquibase(applicationContext)
+    }
+}


### PR DESCRIPTION
Allow plugin users to override the definition of `GrailsLiquibase` instances created per data source

Resolves grails/gorm-hibernate5#963 