### PR TITLE
Upgrade to Liquibase 3.10.1 (also liquibase-hibernate5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 jdk:
-- oraclejdk8
+- openjdk8
 before_install:
 - cat /etc/hosts
 - sudo hostname "$(hostname | cut -c1-63)"

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ One popular approach is to have a root changelog named changlog.groovy (or chang
 * 3.x: Grails 3 with Hibernate 5
 
 ## Documentation
-* Grails 2:                 http://grails-plugins.github.io/grails-database-migration/docs/manual/index.html
-* Grails 3 (Hibernate 4):   http://grails-plugins.github.io/grails-database-migration/2.0.x/index.html
+* Grails 2: http://grails-plugins.github.io/grails-database-migration/docs/manual/index.html
+* Grails 3 (Hibernate 4): http://grails-plugins.github.io/grails-database-migration/2.0.x/index.html
 * Grails 3/4 (Hibernate 5): http://grails-plugins.github.io/grails-database-migration/3.0.x/index.html
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Branches
 
-**master** Version of the plugin compatible with Grails 3 and Hibernate 5.
+**master** Version of the plugin compatible with Grails 3 / 4 and Hibernate 5.
 
 **2.x**. Version of the plugin compatible with Grails 3 and Hibernate 4.
 
@@ -27,11 +27,11 @@ One popular approach is to have a root changelog named changlog.groovy (or chang
 * 3.x: Grails 3 with Hibernate 5
 
 ## Documentation
-* Grails 2: http://grails-plugins.github.io/grails-database-migration/docs/manual/index.html
-* Grails 3 (Hibernate 4): http://grails-plugins.github.io/grails-database-migration/2.0.x/index.html
-* Grails 3 (Hibernate 5): http://grails-plugins.github.io/grails-database-migration/3.0.x/index.html
+* Grails 2:                 http://grails-plugins.github.io/grails-database-migration/docs/manual/index.html
+* Grails 3 (Hibernate 4):   http://grails-plugins.github.io/grails-database-migration/2.0.x/index.html
+* Grails 3/4 (Hibernate 5): http://grails-plugins.github.io/grails-database-migration/3.0.x/index.html
 
 
 ## Package distribution
 
-Software is distrbuted in [Bintray](https://bintray.com/grails/plugins/database-migration)
+Software is distributed on [Bintray](https://bintray.com/grails/plugins/database-migration)

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ configurations {
 dependencies {
     compile "org.liquibase:liquibase-core:$liquibaseVersion"
 
-    compile('org.liquibase.ext:liquibase-hibernate5:3.7') {
+    compile("org.liquibase.ext:liquibase-hibernate5:$liquibaseVersion") {
         exclude group: 'org.hibernate', module: 'hibernate-core'
         exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
         exclude group: 'org.hibernate', module: 'hibernate-envers'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 grailsVersion=3.2.1
 gradleWrapperVersion=3.1
-liquibaseVersion=3.6.1
+liquibaseVersion=3.10.1
 
 websiteUrl=http://grails-plugins.github.io/grails-database-migration
 issueTrackerUrl=https://github.com/grails-plugins/grails-database-migration/issues

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommandSpec.groovy
@@ -51,4 +51,9 @@ abstract class DatabaseMigrationCommandSpec extends Specification {
         changeLogLocation = File.createTempDir()
     }
 
+
+    protected static extractOutput(OutputCapture outputCapture){
+        // outputCapture may contain debug outputs
+        outputCapture.toString().getAt(outputCapture.toString().indexOf("databaseChangeLog")..-1)?.replaceAll(/\s/,"")
+    }
 }

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommandSpec.groovy
@@ -39,13 +39,11 @@ class DbmDiffCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec 
         otherDbDataSource.driverClassName = Driver.name
         otherDbConnection = otherDbDataSource.connection
         otherDbSql = new Sql(otherDbConnection)
-        otherDbSql.executeUpdate '''
-CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id))
-'''
+        otherDbSql.executeUpdate 'CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id))'
         sql.executeUpdate '''
-CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, price INT NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id));
-CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, CONSTRAINT PK_AUTHOR PRIMARY KEY (id));
-'''
+            CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, price INT NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id));
+            CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, CONSTRAINT PK_AUTHOR PRIMARY KEY (id));
+            '''
     }
 
     def "writes Change Log to update the database to STDOUT"() {
@@ -53,30 +51,31 @@ CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL,
             command.handle(getExecutionContext('other'))
 
         then:
-            outputCapture.toString() =~ '''
-databaseChangeLog = \\{
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        createTable\\(tableName: "AUTHOR"\\) \\{
-            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
+        String expected = extractOutput(outputCapture)
+        expected =~ '''
+            databaseChangeLog = \\{
+            
+                changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                    createTable\\(tableName: "AUTHOR"\\) \\{
+                        column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                            constraints\\(nullable:"false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
+                        \\}
+            
+                        column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
+                            constraints\\(nullable: "false"\\)
+                        \\}
+                    \\}
+                \\}
+            
+                changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                    addColumn\\(tableName: "BOOK"\\) \\{
+                        column\\(name: "PRICE", type: "INTEGER"\\) \\{
+                            constraints\\(nullable: "false"\\)
+                        \\}
+                    \\}
+                \\}
             \\}
-
-            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        addColumn\\(tableName: "BOOK"\\) \\{
-            column\\(name: "PRICE", type: "INTEGER"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-\\}
-'''.trim()
+        '''.replaceAll(/\s/,"")
     }
 
     def "writes Change Log to update the database to a file given as arguments"() {
@@ -87,13 +86,13 @@ databaseChangeLog = \\{
             command.handle(getExecutionContext('other', outputChangeLog.name))
 
         then:
-            outputChangeLog.text =~ '''
+            outputChangeLog.text?.replaceAll(/\s/,"") =~ '''
 databaseChangeLog = \\{
 
     changeSet\\(author: ".+?", id: ".+?"\\) \\{
         createTable\\(tableName: "AUTHOR"\\) \\{
             column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
+                constraints\\(nullable:"false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
             \\}
 
             column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
@@ -110,7 +109,7 @@ databaseChangeLog = \\{
         \\}
     \\}
 \\}
-'''.trim()
+'''.replaceAll(/\s/,"")
     }
 
     def "an error occurs if the otherEnv parameter is not specified"() {

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommandSpec.groovy
@@ -39,11 +39,13 @@ class DbmDiffCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec 
         otherDbDataSource.driverClassName = Driver.name
         otherDbConnection = otherDbDataSource.connection
         otherDbSql = new Sql(otherDbConnection)
-        otherDbSql.executeUpdate 'CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id))'
+        otherDbSql.executeUpdate '''
+CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id))
+'''
         sql.executeUpdate '''
-            CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, price INT NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id));
-            CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, CONSTRAINT PK_AUTHOR PRIMARY KEY (id));
-            '''
+CREATE TABLE book (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, price INT NOT NULL, CONSTRAINT PK_BOOK PRIMARY KEY (id));
+CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, CONSTRAINT PK_AUTHOR PRIMARY KEY (id));
+'''
     }
 
     def "writes Change Log to update the database to STDOUT"() {
@@ -53,29 +55,29 @@ class DbmDiffCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec 
         then:
         String expected = extractOutput(outputCapture)
         expected =~ '''
-            databaseChangeLog = \\{
-            
-                changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                    createTable\\(tableName: "AUTHOR"\\) \\{
-                        column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                            constraints\\(nullable:"false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
-                        \\}
-            
-                        column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
-                            constraints\\(nullable: "false"\\)
-                        \\}
-                    \\}
-                \\}
-            
-                changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                    addColumn\\(tableName: "BOOK"\\) \\{
-                        column\\(name: "PRICE", type: "INTEGER"\\) \\{
-                            constraints\\(nullable: "false"\\)
-                        \\}
-                    \\}
-                \\}
+databaseChangeLog = \\{
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        createTable\\(tableName: "AUTHOR"\\) \\{
+            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                constraints\\(nullable:"false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
             \\}
-        '''.replaceAll(/\s/,"")
+
+            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        addColumn\\(tableName: "BOOK"\\) \\{
+            column\\(name: "PRICE", type: "INTEGER"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+\\}
+'''.replaceAll(/\s/,"")
     }
 
     def "writes Change Log to update the database to a file given as arguments"() {

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommandSpec.groovy
@@ -34,37 +34,37 @@ CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL,
 
         then:
             extractOutput(outputCapture) =~ '''
-                databaseChangeLog = \\{
-                
-                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-                        createTable\\(tableName: "AUTHOR"\\) \\{
-                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
-                            \\}
-                
-                            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                
-                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-                        createTable\\(tableName: "BOOK"\\) \\{
-                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
-                            \\}
-                
-                            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "PRICE", type: "INT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                \\}
-                '''.replaceAll(/\s/, "")
+databaseChangeLog = \\{
+
+    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+        createTable\\(tableName: "AUTHOR"\\) \\{
+            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
+            \\}
+
+            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+        createTable\\(tableName: "BOOK"\\) \\{
+            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
+            \\}
+
+            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "PRICE", type: "INT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+\\}
+'''.replaceAll(/\s/, "")
     }
 
     def "generates an initial changelog from the database to a file given as arguments"() {
@@ -76,36 +76,36 @@ CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL,
 
         then:
             outputChangeLog.text?.replaceAll(/\s/, "") =~ '''
-                databaseChangeLog = \\{
-                
-                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-                        createTable\\(tableName: "AUTHOR"\\) \\{
-                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
-                            \\}
-                
-                            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                
-                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-                        createTable\\(tableName: "BOOK"\\) \\{
-                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
-                            \\}
-                
-                            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "PRICE", type: "INT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                \\}
-                '''.replaceAll(/\s/, "")
+databaseChangeLog = \\{
+
+    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+        createTable\\(tableName: "AUTHOR"\\) \\{
+            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
+            \\}
+
+            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+        createTable\\(tableName: "BOOK"\\) \\{
+            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
+            \\}
+
+            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "PRICE", type: "INT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+\\}
+'''.replaceAll(/\s/, "")
     }
 }

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommandSpec.groovy
@@ -33,38 +33,38 @@ CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL,
             command.handle(getExecutionContext())
 
         then:
-            outputCapture.toString() =~ '''
-databaseChangeLog = \\{
-
-    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-        createTable\\(tableName: "AUTHOR"\\) \\{
-            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
-            \\}
-
-            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-        createTable\\(tableName: "BOOK"\\) \\{
-            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
-            \\}
-
-            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "PRICE", type: "INT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-\\}
-'''.trim()
+            extractOutput(outputCapture) =~ '''
+                databaseChangeLog = \\{
+                
+                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+                        createTable\\(tableName: "AUTHOR"\\) \\{
+                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
+                            \\}
+                
+                            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                
+                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+                        createTable\\(tableName: "BOOK"\\) \\{
+                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
+                            \\}
+                
+                            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "PRICE", type: "INT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                \\}
+                '''.replaceAll(/\s/, "")
     }
 
     def "generates an initial changelog from the database to a file given as arguments"() {
@@ -75,37 +75,37 @@ databaseChangeLog = \\{
             command.handle(getExecutionContext(outputChangeLog.name))
 
         then:
-            outputChangeLog.text =~ '''
-databaseChangeLog = \\{
-
-    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-        createTable\\(tableName: "AUTHOR"\\) \\{
-            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
-            \\}
-
-            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".*?", id: ".*?"\\) \\{
-        createTable\\(tableName: "BOOK"\\) \\{
-            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
-            \\}
-
-            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "PRICE", type: "INT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-\\}
-'''.trim()
+            outputChangeLog.text?.replaceAll(/\s/, "") =~ '''
+                databaseChangeLog = \\{
+                
+                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+                        createTable\\(tableName: "AUTHOR"\\) \\{
+                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_AUTHOR"\\)
+                            \\}
+                
+                            column\\(name: "NAME", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                
+                    changeSet\\(author: ".*?", id: ".*?"\\) \\{
+                        createTable\\(tableName: "BOOK"\\) \\{
+                            column\\(autoIncrement: "true", name: "ID", type: "INT"\\) \\{
+                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "PK_BOOK"\\)
+                            \\}
+                
+                            column\\(name: "TITLE", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "PRICE", type: "INT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                \\}
+                '''.replaceAll(/\s/, "")
     }
 }

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommandSpec.groovy
@@ -28,57 +28,49 @@ class DbmGenerateGormChangelogCommandSpec extends ApplicationContextDatabaseMigr
 
         then:
         extractOutput(outputCapture) =~ '''
-            databaseChangeLog = \\{
-            
-                changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                    createTable\\(tableName: "author"\\) \\{
-                        column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                            constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "authorPK"\\)
-                        \\}
-            
-                        column\\(name: "version", type: "BIGINT"\\) \\{
-                            constraints\\(nullable: "false"\\)
-                        \\}
-            
-                        column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
-                            constraints\\(nullable: "false"\\)
-                        \\}
-                    \\}
-                \\}
-            
-                changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                    createTable\\(tableName: "book"\\) \\{
-                        column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                            constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
-                        \\}
-            
-                        column\\(name: "version", type: "BIGINT"\\) \\{
-                            constraints\\(nullable: "false"\\)
-                        \\}
-            
-                        column\\(name: "author_id", type: "BIGINT"\\) \\{
-                            constraints\\(nullable: "false"\\)
-                        \\}
-            
-                        column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                            constraints\\(nullable: "false"\\)
-                        \\}
-                    \\}
-                \\}
-            
-                changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                    addForeignKeyConstraint\\(
-                        baseColumnNames: "author_id", 
-                        baseTableName: "book", 
-                        constraintName: "FK.+?", 
-                        deferrable: "false", 
-                        initiallyDeferred: "false", 
-                        referencedColumnNames: "id", 
-                        referencedTableName: "author", 
-                        validate: "true"\\)
-                \\}
+databaseChangeLog = \\{
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        createTable\\(tableName: "author"\\) \\{
+            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "authorPK"\\)
             \\}
-            '''.replaceAll(/\s/,"")
+
+            column\\(name: "version", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        createTable\\(tableName: "book"\\) \\{
+            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+            \\}
+
+            column\\(name: "version", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "author_id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
+    \\}
+\\}
+'''.replaceAll(/\s/,"")
     }
 
     def "writes Change Log to copy the current state of the database to a file given as arguments"() {
@@ -91,57 +83,49 @@ class DbmGenerateGormChangelogCommandSpec extends ApplicationContextDatabaseMigr
         then:
             def output = new File(changeLogLocation, filename).text?.replaceAll(/\s/, "")
             output =~ '''
-                databaseChangeLog = \\{
-                
-                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                        createTable\\(tableName: "author"\\) \\{
-                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "authorPK"\\)
-                            \\}
-                
-                            column\\(name: "version", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                
-                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                        createTable\\(tableName: "book"\\) \\{
-                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
-                            \\}
-                
-                            column\\(name: "version", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "author_id", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                
-                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                        addForeignKeyConstraint\\(
-                            baseColumnNames: "author_id", 
-                            baseTableName: "book", 
-                            constraintName: "FK.+?", 
-                            deferrable: "false", 
-                            initiallyDeferred: "false", 
-                            referencedColumnNames: "id", 
-                            referencedTableName: "author", 
-                            validate: "true"\\)
-                    \\}
-                \\}
-                '''.replaceAll(/\s/, "")
+databaseChangeLog = \\{
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        createTable\\(tableName: "author"\\) \\{
+            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "authorPK"\\)
+            \\}
+
+            column\\(name: "version", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        createTable\\(tableName: "book"\\) \\{
+            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+            \\}
+
+            column\\(name: "version", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "author_id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
+    \\}
+\\}
+'''.replaceAll(/\s/, "")
     }
 
     def "an error occurs if changeLogFile already exists"() {

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommandSpec.groovy
@@ -27,50 +27,58 @@ class DbmGenerateGormChangelogCommandSpec extends ApplicationContextDatabaseMigr
             command.handle(getExecutionContext())
 
         then:
-            outputCapture.toString() =~ '''
-databaseChangeLog = \\{
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        createTable\\(tableName: "author"\\) \\{
-            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "authorPK"\\)
+        extractOutput(outputCapture) =~ '''
+            databaseChangeLog = \\{
+            
+                changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                    createTable\\(tableName: "author"\\) \\{
+                        column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                            constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "authorPK"\\)
+                        \\}
+            
+                        column\\(name: "version", type: "BIGINT"\\) \\{
+                            constraints\\(nullable: "false"\\)
+                        \\}
+            
+                        column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
+                            constraints\\(nullable: "false"\\)
+                        \\}
+                    \\}
+                \\}
+            
+                changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                    createTable\\(tableName: "book"\\) \\{
+                        column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                            constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+                        \\}
+            
+                        column\\(name: "version", type: "BIGINT"\\) \\{
+                            constraints\\(nullable: "false"\\)
+                        \\}
+            
+                        column\\(name: "author_id", type: "BIGINT"\\) \\{
+                            constraints\\(nullable: "false"\\)
+                        \\}
+            
+                        column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                            constraints\\(nullable: "false"\\)
+                        \\}
+                    \\}
+                \\}
+            
+                changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                    addForeignKeyConstraint\\(
+                        baseColumnNames: "author_id", 
+                        baseTableName: "book", 
+                        constraintName: "FK.+?", 
+                        deferrable: "false", 
+                        initiallyDeferred: "false", 
+                        referencedColumnNames: "id", 
+                        referencedTableName: "author", 
+                        validate: "true"\\)
+                \\}
             \\}
-
-            column\\(name: "version", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        createTable\\(tableName: "book"\\) \\{
-            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "bookPK"\\)
-            \\}
-
-            column\\(name: "version", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "author_id", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
-    \\}
-\\}
-'''.trim()
+            '''.replaceAll(/\s/,"")
     }
 
     def "writes Change Log to copy the current state of the database to a file given as arguments"() {
@@ -81,51 +89,59 @@ databaseChangeLog = \\{
             command.handle(getExecutionContext(filename))
 
         then:
-            def output = new File(changeLogLocation, filename).text
+            def output = new File(changeLogLocation, filename).text?.replaceAll(/\s/, "")
             output =~ '''
-databaseChangeLog = \\{
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        createTable\\(tableName: "author"\\) \\{
-            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "authorPK"\\)
-            \\}
-
-            column\\(name: "version", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        createTable\\(tableName: "book"\\) \\{
-            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "bookPK"\\)
-            \\}
-
-            column\\(name: "version", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "author_id", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
-    \\}
-\\}
-'''.trim()
+                databaseChangeLog = \\{
+                
+                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                        createTable\\(tableName: "author"\\) \\{
+                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "authorPK"\\)
+                            \\}
+                
+                            column\\(name: "version", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "name", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                
+                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                        createTable\\(tableName: "book"\\) \\{
+                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+                            \\}
+                
+                            column\\(name: "version", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "author_id", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                
+                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                        addForeignKeyConstraint\\(
+                            baseColumnNames: "author_id", 
+                            baseTableName: "book", 
+                            constraintName: "FK.+?", 
+                            deferrable: "false", 
+                            initiallyDeferred: "false", 
+                            referencedColumnNames: "id", 
+                            referencedTableName: "author", 
+                            validate: "true"\\)
+                    \\}
+                \\}
+                '''.replaceAll(/\s/, "")
     }
 
     def "an error occurs if changeLogFile already exists"() {

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommandSpec.groovy
@@ -33,33 +33,33 @@ class DbmGormDiffCommandSpec extends ApplicationContextDatabaseMigrationCommandS
         then:
             def output = extractOutput(outputCapture).replaceAll(/\s/,"")
             output ==~ '''
-                databaseChangeLog = \\{
-                
-                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                        createTable\\(tableName: "book"\\) \\{
-                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
-                            \\}
-                
-                            column\\(name: "version", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "author_id", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                
-                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
-                    \\}
-                \\}
-                '''.replaceAll(/\s/,"")
+databaseChangeLog = \\{
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        createTable\\(tableName: "book"\\) \\{
+            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+            \\}
+
+            column\\(name: "version", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "author_id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
+    \\}
+\\}
+'''.replaceAll(/\s/,"")
     }
 
     def "diffs GORM classes against a database and generates a changelog to a file given as arguments"() {
@@ -72,33 +72,33 @@ class DbmGormDiffCommandSpec extends ApplicationContextDatabaseMigrationCommandS
         then:
             def output = new File(changeLogLocation, filename).text?.replaceAll(/\s/,"")
             output =~ '''
-                databaseChangeLog = \\{
-                
-                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                        createTable\\(tableName: "book"\\) \\{
-                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                                constraints\\(nullable:"false", primaryKey: "true", primaryKeyName: "bookPK"\\)
-                            \\}
-                
-                            column\\(name: "version", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "author_id", type: "BIGINT"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                
-                            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                                constraints\\(nullable: "false"\\)
-                            \\}
-                        \\}
-                    \\}
-                
-                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-                        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
-                    \\}
-                \\}
-            '''.replaceAll(/\s/,"")
+databaseChangeLog = \\{
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        createTable\\(tableName: "book"\\) \\{
+            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                constraints\\(nullable:"false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+            \\}
+
+            column\\(name: "version", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "author_id", type: "BIGINT"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+
+            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                constraints\\(nullable: "false"\\)
+            \\}
+        \\}
+    \\}
+
+    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
+    \\}
+\\}
+'''.replaceAll(/\s/,"")
     }
 
     def "an error occurs if changeLogFile already exists"() {

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommandSpec.groovy
@@ -31,35 +31,35 @@ class DbmGormDiffCommandSpec extends ApplicationContextDatabaseMigrationCommandS
             command.handle(getExecutionContext())
 
         then:
-            def output = outputCapture.toString()
-            output =~ '''
-databaseChangeLog = \\{
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        createTable\\(tableName: "book"\\) \\{
-            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "bookPK"\\)
-            \\}
-
-            column\\(name: "version", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "author_id", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
-    \\}
-\\}
-'''.trim()
+            def output = extractOutput(outputCapture).replaceAll(/\s/,"")
+            output ==~ '''
+                databaseChangeLog = \\{
+                
+                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                        createTable\\(tableName: "book"\\) \\{
+                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+                            \\}
+                
+                            column\\(name: "version", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "author_id", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                
+                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
+                    \\}
+                \\}
+                '''.replaceAll(/\s/,"")
     }
 
     def "diffs GORM classes against a database and generates a changelog to a file given as arguments"() {
@@ -70,35 +70,35 @@ databaseChangeLog = \\{
             command.handle(getExecutionContext(filename))
 
         then:
-            def output = new File(changeLogLocation, filename).text
+            def output = new File(changeLogLocation, filename).text?.replaceAll(/\s/,"")
             output =~ '''
-databaseChangeLog = \\{
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        createTable\\(tableName: "book"\\) \\{
-            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
-                constraints\\(primaryKey: "true", primaryKeyName: "bookPK"\\)
-            \\}
-
-            column\\(name: "version", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "author_id", type: "BIGINT"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-
-            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
-                constraints\\(nullable: "false"\\)
-            \\}
-        \\}
-    \\}
-
-    changeSet\\(author: ".+?", id: ".+?"\\) \\{
-        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
-    \\}
-\\}
-'''.trim()
+                databaseChangeLog = \\{
+                
+                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                        createTable\\(tableName: "book"\\) \\{
+                            column\\(autoIncrement: "true", name: "id", type: "BIGINT"\\) \\{
+                                constraints\\(nullable:"false", primaryKey: "true", primaryKeyName: "bookPK"\\)
+                            \\}
+                
+                            column\\(name: "version", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "author_id", type: "BIGINT"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                
+                            column\\(name: "title", type: "VARCHAR\\(255\\)"\\) \\{
+                                constraints\\(nullable: "false"\\)
+                            \\}
+                        \\}
+                    \\}
+                
+                    changeSet\\(author: ".+?", id: ".+?"\\) \\{
+                        addForeignKeyConstraint\\(baseColumnNames: "author_id", baseTableName: "book", constraintName: "FK.+?", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "author", validate: "true"\\)
+                    \\}
+                \\}
+            '''.replaceAll(/\s/,"")
     }
 
     def "an error occurs if changeLogFile already exists"() {

--- a/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSpec.groovy
@@ -70,20 +70,20 @@ databaseChangeLog = {
         given:
         DbmUpdateCommand command = (DbmUpdateCommand)createCommand(DbmUpdateCommand)
             command.changeLogFile << """
-                databaseChangeLog = {
-                    changeSet(author: "John Smith", id: "1") {
-                        grailsChange {
-                            validate {
-                                ${GroovyChangeLogSpec.name}.calledBlocks << 'validate'
-                                error('error message')
-                            }
-                            change {
-                                ${GroovyChangeLogSpec.name}.calledBlocks << 'change'
-                            }
-                        }
-                    }
-                }
-            """
+databaseChangeLog = {
+    changeSet(author: "John Smith", id: "1") {
+        grailsChange {
+            validate {
+                ${GroovyChangeLogSpec.name}.calledBlocks << 'validate'
+                error('error message')
+            }
+            change {
+                ${GroovyChangeLogSpec.name}.calledBlocks << 'change'
+            }
+        }
+    }
+}
+"""
         when:
             command.handle(getExecutionContext(DbmUpdateCommand))
 

--- a/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSpec.groovy
@@ -4,13 +4,13 @@ import grails.core.GrailsApplication
 import liquibase.exception.ValidationFailedException
 import org.grails.plugins.databasemigration.command.*
 
-
 class GroovyChangeLogSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 
     static List<String> calledBlocks
 
     def setup() {
         calledBlocks = []
+        Locale.setDefault(new Locale("en", "US"))
     }
 
     def "updates a database with Groovy Change"() {
@@ -66,26 +66,24 @@ databaseChangeLog = {
             calledBlocks == ['validate', 'change']
     }
 
-
-
     def "stops processing by calling the error method"() {
         given:
-            def command = createCommand(DbmUpdateCommand)
+        DbmUpdateCommand command = (DbmUpdateCommand)createCommand(DbmUpdateCommand)
             command.changeLogFile << """
-databaseChangeLog = {
-    changeSet(author: "John Smith", id: "1") {
-        grailsChange {
-            validate {
-                ${GroovyChangeLogSpec.name}.calledBlocks << 'validate'
-                error('error message')
-            }
-            change {
-                ${GroovyChangeLogSpec.name}.calledBlocks << 'change'
-            }
-        }
-    }
-}
-"""
+                databaseChangeLog = {
+                    changeSet(author: "John Smith", id: "1") {
+                        grailsChange {
+                            validate {
+                                ${GroovyChangeLogSpec.name}.calledBlocks << 'validate'
+                                error('error message')
+                            }
+                            change {
+                                ${GroovyChangeLogSpec.name}.calledBlocks << 'change'
+                            }
+                        }
+                    }
+                }
+            """
         when:
             command.handle(getExecutionContext(DbmUpdateCommand))
 

--- a/src/test/resources/logback.groovy
+++ b/src/test/resources/logback.groovy
@@ -11,6 +11,8 @@ root(ERROR, ['STDOUT'])
 
 logger("org.grails", DEBUG, ['STDOUT'], false)
 logger("liquibase", DEBUG, ['STDOUT'], false)
+logger("org.grails.datastore.gorm.GormEnhancer", INFO, ['STDOUT'], false)
+logger("org.grails.plugin.datasource.TomcatJDBCPoolMBeanExporter", WARN, ['STDOUT'], false)
 
 
 


### PR DESCRIPTION
- This finally fixes the excessive index / foreign key constraint recreations
- Fixed tests by extracting changeLog part (Due to polluted outputCapture)
- Fixes GroovyChangeLogSpec if default JVM langauge is not en.
- String comparisons are now done without spaces in tests
- fixes #95 #100 #159

Tested successfully with Grails 4.0.3 in a fairly complex project.