### PR TITLE
Commands fails to include changesets from classpath

### DIFF
--- a/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
@@ -48,6 +48,7 @@ import liquibase.lockservice.LockService
 import liquibase.lockservice.LockServiceFactory
 import liquibase.parser.ChangeLogParserFactory
 import liquibase.resource.ClassLoaderResourceAccessor
+import liquibase.resource.CompositeResourceAccessor
 import liquibase.resource.FileSystemResourceAccessor
 import liquibase.resource.ResourceAccessor
 import liquibase.statement.core.RawSqlStatement
@@ -185,7 +186,10 @@ trait DatabaseMigrationCommand {
     }
 
     ResourceAccessor createResourceAccessor() {
-        new FileSystemResourceAccessor(changeLogLocation.path)
+        new CompositeResourceAccessor(
+            new FileSystemResourceAccessor(changeLogLocation.path),
+            new ClassLoaderResourceAccessor())
+
     }
 
     void withDatabase(Map<String, String> dataSourceConfig = null, @ClosureParams(value = SimpleType, options = 'liquibase.database.Database') Closure closure) {

--- a/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/liquibase/GroovyChangeLogSpec.groovy
@@ -105,7 +105,7 @@ databaseChangeLog = {
         grailsChange {
             change {
                 assert changeSet.id == '4'
-                assert resourceAccessor.toString() == 'liquibase.resource.FileSystemResourceAccessor(${changeLogLocation.canonicalPath.replace('\\', '\\\\')})'
+                assert resourceAccessor.toString().startsWith('liquibase.resource.CompositeResourceAccessor(liquibase.resource.FileSystemResourceAccessor(${changeLogLocation.canonicalPath.replace('\\', '\\\\')}),liquibase.resource.ClassLoaderResourceAccessor(')
                 assert ctx.hashCode() == ${applicationContext.hashCode()}
                 assert application.hashCode() == ${applicationContext.getBean(GrailsApplication).hashCode()}
                 ${GroovyChangeLogSpec.name}.calledBlocks << 'change'
@@ -195,7 +195,7 @@ databaseChangeLog = {
         grailsChange {
             rollback {
                 assert changeSet.id == '9'
-                assert resourceAccessor.toString() == 'liquibase.resource.FileSystemResourceAccessor(${changeLogLocation.canonicalPath.replace('\\', '\\\\')})'
+                assert resourceAccessor.toString().startsWith('liquibase.resource.CompositeResourceAccessor(liquibase.resource.FileSystemResourceAccessor(${changeLogLocation.canonicalPath.replace('\\', '\\\\')}),liquibase.resource.ClassLoaderResourceAccessor(')
                 assert ctx.hashCode() == ${applicationContext.hashCode()}
                 assert application.hashCode() == ${applicationContext.getBean(GrailsApplication).hashCode()}
                 ${GroovyChangeLogSpec.name}.calledBlocks << 'rollback'


### PR DESCRIPTION
If a changeset includes an other file that is inside a jar the execution of most dbm... gradle commands fails, since resources are only loaded from file system.