### PR TITLE
#152 call callback methods only on pending migrations (as in 1.x) (3.0.x branch)

### DIFF
--- a/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GrailsLiquibase.groovy
+++ b/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GrailsLiquibase.groovy
@@ -16,6 +16,8 @@
 package org.grails.plugins.databasemigration.liquibase
 
 import groovy.transform.CompileStatic
+import liquibase.Contexts
+import liquibase.LabelExpression
 import liquibase.Liquibase
 import liquibase.database.Database
 import liquibase.exception.DatabaseException
@@ -87,9 +89,18 @@ class GrailsLiquibase extends SpringLiquibase {
         def database = liquibase.database
         def migrationCallbacks = applicationContext.getBean('migrationCallbacks')
 
+
+        if (!liquibase.listUnrunChangeSets(new Contexts(getContexts()), new LabelExpression(getLabels()))) {
+            log.info("No migrations to run for ${liquibase.database.connection.catalog}")
+            return
+        }
+
+        log.info("Migrations detected for ${liquibase.database.connection.catalog}")
+
         if (migrationCallbacks.metaClass.respondsTo(migrationCallbacks, 'beforeStartMigration')) {
             migrationCallbacks.invokeMethod('beforeStartMigration', [database] as Object[])
         }
+
         if (migrationCallbacks.metaClass.respondsTo(migrationCallbacks, 'onStartMigration')) {
             migrationCallbacks.invokeMethod('onStartMigration', [database, liquibase, changeLog] as Object[])
         }


### PR DESCRIPTION
- Bring back bahaviour as in 1.x to call the callback methods only when pending changes are detected
- fixes #152 