### PR TITLE
Fix missing dependency problems by changing the scope from implementa…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,17 +51,21 @@ dependencies {
     api("org.grails:grails-shell") {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }
-    implementation "org.hibernate:hibernate-core:5.6.1.Final"
+    compileOnly "org.hibernate:hibernate-core:5.6.1.Final"
 
-    implementation 'org.springframework.boot:spring-boot-starter-logging'
-    implementation "org.springframework.boot:spring-boot-starter-actuator"
-    implementation "org.springframework.boot:spring-boot-autoconfigure"
-    implementation "org.springframework.boot:spring-boot-starter-tomcat"
+    compileOnly 'org.springframework.boot:spring-boot-starter-logging'
+    compileOnly "org.springframework.boot:spring-boot-starter-actuator"
+    compileOnly "org.springframework.boot:spring-boot-autoconfigure"
+    compileOnly "org.springframework.boot:spring-boot-starter-tomcat"
 
-    implementation "org.grails:grails-web-boot"
-    implementation "org.grails:grails-dependencies"
-    implementation 'javax.servlet:javax.servlet-api:4.0.1'
-    implementation "org.grails.plugins:hibernate5"
+    compileOnly "org.grails:grails-web-boot"
+    compileOnly "org.grails:grails-dependencies"
+    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
+    compileOnly "org.grails.plugins:hibernate5"
+
+    testImplementation "org.springframework.boot:spring-boot-starter-tomcat"
+    testImplementation "org.hibernate:hibernate-core:5.6.1.Final"
+    testImplementation "org.grails.plugins:hibernate5"
 
     testImplementation "org.grails:grails-gorm-testing-support"
     testImplementation "org.mockito:mockito-core"


### PR DESCRIPTION
…tion to compileOnly

The buildsciprt does not resolve dependency version from the Grails BOM, so but defining the dependency scope as implementation add information to the POM without version which breaks when add the plugin to build dependency. Changing the scope to compileOnly will skip dependency from POM which will resolve imissing dependency errors.

Fixes #229