### PR TITLE
Liquibase dependencies: exclude liquibase-test-harness and h2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
         exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
         exclude group: 'org.hibernate', module: 'hibernate-envers'
         exclude group: 'org.liquibase', module: 'liquibase-core'
+        exclude group: 'org.liquibase', module: 'liquibase-test-harness'
+        exclude group: 'com.h2database', module: 'h2'
     }
     api("org.grails:grails-shell") {
         exclude group: 'org.slf4j', module: 'slf4j-simple'


### PR DESCRIPTION
Exclude liquibase-test-harness and h2 from liquibase-hibernate5, because they depend on too much database driver and groovy jars.