### PR TITLE
Issue 305 - Upgrade liquibase to remove h2 transitive dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 grailsVersion=5.1.7
 grailsGradlePluginVersion=5.1.3
 groovyVersion=3.0.10
-liquibaseVersion=4.9.0
-liquibaseHibernateVersion=4.9.0
+liquibaseVersion=4.18.0
+liquibaseHibernateVersion=4.18.0
 projectVersion=4.1.1-SNAPSHOT
 
 websiteUrl=https://grails-plugins.github.io/grails-database-migration

--- a/src/test/groovy/org/grails/plugins/databasemigration/command/DbmStatusCommandSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/databasemigration/command/DbmStatusCommandSpec.groovy
@@ -36,7 +36,7 @@ class DbmStatusCommandSpec extends ApplicationContextDatabaseMigrationCommandSpe
             command.handle(getExecutionContext())
 
         then:
-            output.toString().contains('2 change sets have not been applied')
+            output.toString().contains('2 changesets have not been applied')
     }
 
     def "outputs count or list of unrun change sets to a file given as arguments"() {
@@ -47,7 +47,7 @@ class DbmStatusCommandSpec extends ApplicationContextDatabaseMigrationCommandSpe
             command.handle(getExecutionContext(outputFile.canonicalPath))
 
         then:
-            outputFile.text.contains('2 change sets have not been applied')
+            outputFile.text.contains('2 changesets have not been applied')
     }
 
     static final String CHANGE_LOG_CONTENT = '''


### PR DESCRIPTION
Upgrade Liquibase to version that no longer contains h2 as a dependency. This prevents h2 being pulled into projects that use this plugin.

Addresses: #305 & grails/grails-core/issues/11753
