### PR TITLE
Merge pull request #397 from MichaelMorett/feature/fix-getting-started

### DIFF
--- a/src/docs/asciidoc/gettingStarted.adoc
+++ b/src/docs/asciidoc/gettingStarted.adoc
@@ -27,7 +27,7 @@ dependencies {
 }
 ----
 
-You should also tell Gradle about the migrations folder. If using Grails 4, make sure the configuration below is BEFORE the
+You should also tell Gradle about the migrations folder. If using Grails 4 or above, make sure the configuration below is BEFORE the
 `dependencies` configuration, so that the `sourceSets` declaration takes effect.
 
 [source,groovy,subs="attributes"]


### PR DESCRIPTION
docs: mentioned that the placement of sourceSets affects Grails 4 and above (cherry picked from commit 4cc66c98068f17dea83e58839fb246230949f305)